### PR TITLE
fix clippy

### DIFF
--- a/src/base64.rs
+++ b/src/base64.rs
@@ -19,7 +19,7 @@ fn base64<R: Read, W: Write>(f: &mut W, r: &mut R, m: &clap::ArgMatches<'_>) -> 
         .value_of("wrap")
         .ok_or_else(|| Base64Error::InvalidParam("--wrap".to_string()))?
         .parse::<usize>()
-        .or_else(|_| Err(Error::new(Base64Error::InvalidParam("--wrap".to_string()))))?;
+        .map_err(|_| Error::new(Base64Error::InvalidParam("--wrap".to_string())))?;
     let mut buf = Vec::new();
 
     r.read_to_end(&mut buf)?;


### PR DESCRIPTION
fix the following warning.

<https://github.com/rarewin/rust-coreutils/actions/runs/155589096>

```
warning: using `Result.or_else(|x| Err(y))`, which is more succinctly expressed as `map_err(|x| y)`
  --> src/base64.rs:18:16                                           
   |                                                                                                                                                                                                                                                                              
18 |       let wrap = m                                                                                                                                                                                                                                                           
   |  ________________^                                                                                                                                                                                                                                                           
19 | |         .value_of("wrap")                                                                                                                                                                                                                                                  
20 | |         .ok_or_else(|| Base64Error::InvalidParam("--wrap".to_string()))?
21 | |         .parse::<usize>()                      
22 | |         .or_else(|_| Err(Error::new(Base64Error::InvalidParam("--wrap".to_string()))))?;
   | |______________________________________________________________________________________^                                                                                                                                                                                     
   |                                                   
   = note: `#[warn(clippy::bind_instead_of_map)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bind_instead_of_map
help: try this                         
   |                                  
18 |     let wrap = m                                       
19 |         .value_of("wrap")                      
20 |         .ok_or_else(|| Base64Error::InvalidParam("--wrap".to_string()))?                                                            
21 |         .parse::<usize>().map_err(|_| Error::new(Base64Error::InvalidParam("--wrap".to_string())))?;
   |                                                                                                                                     
                                                                                                                                         
warning: 1 warning emitted
```